### PR TITLE
Fix empty value handling

### DIFF
--- a/src/Models/ContentSanitiser.php
+++ b/src/Models/ContentSanitiser.php
@@ -54,7 +54,9 @@ class ContentSanitiser {
             'HTML.AllowedElements' => self::getAllowedHTMLTagsAsArray(),
             'HTML.AllowedAttributes' => ['href'],
             'URI.AllowedSchemes' => ['http','https','mailto','callto'],
-            'Attr.ID.HTML5' => true
+            'Attr.ID.HTML5' => true,
+            'AutoFormat.RemoveEmpty.RemoveNbsp' => true,
+            'AutoFormat.RemoveEmpty' => true
         ];
     }
 
@@ -73,6 +75,11 @@ class ContentSanitiser {
             }
             $purifier = new \HTMLPurifier($htmlPurifierConfig);
             $cleaned = $purifier->purify($dirtyHtml);
+            if(trim(strip_tags($cleaned ?? '')) === '') {
+                return '';
+            } else {
+                return $cleaned;
+            }
             return $cleaned;
         } catch (\Exception $e) {
             return htmlentities($dirtyHtml, ENT_QUOTES|ENT_HTML5, "UTF-8");

--- a/templates/NSWDPC/Utilities/Trumbowyg/Script.ss
+++ b/templates/NSWDPC/Utilities/Trumbowyg/Script.ss
@@ -1,5 +1,17 @@
 (function($) {
     $(document).ready(function() {
-        $('textarea#{$ID}[data-tw="1"]').trumbowyg({$Options.RAW});
+        $('textarea#{$ID}[data-tw="1"]')
+            .trumbowyg({$Options.RAW})
+            .on('tbwblur', function(e) {
+                try {
+                    let el = new DOMParser().parseFromString($(this).val(), 'text/html');
+                    let txt = el.documentElement.textContent.trim();
+                    if(txt == '') {
+                        $(this).val('');
+                    }
+                } catch (e) {
+                    console.warn('Could not parse value');
+                }
+            });
     })
 }(jQuery));

--- a/tests/FieldTest.php
+++ b/tests/FieldTest.php
@@ -119,7 +119,9 @@ HTML;
             'HTML.AllowedElements' => $expectedGeneratedTags,
             'HTML.AllowedAttributes' => ['href'],
             'URI.AllowedSchemes' => ['http','https', 'mailto', 'callto'],
-            'Attr.ID.HTML5' => true
+            'Attr.ID.HTML5' => true,
+            'AutoFormat.RemoveEmpty.RemoveNbsp' => true,
+            'AutoFormat.RemoveEmpty' => true
         ];
         $this->assertEquals( $expected, $config, "Configuration is not as expected" );
     }
@@ -144,7 +146,9 @@ HTML;
             'HTML.AllowedElements' => $expectedGeneratedTags,
             'HTML.AllowedAttributes' => ['href'],
             'URI.AllowedSchemes' => ['http','https', 'mailto', 'callto'],
-            'Attr.ID.HTML5' => true
+            'Attr.ID.HTML5' => true,
+            'AutoFormat.RemoveEmpty.RemoveNbsp' => true,
+            'AutoFormat.RemoveEmpty' => true
         ];
         $this->assertEquals( $expected, $config, "Configuration is not as expected" );
     }

--- a/tests/FieldTest.php
+++ b/tests/FieldTest.php
@@ -149,4 +149,24 @@ HTML;
         $this->assertEquals( $expected, $config, "Configuration is not as expected" );
     }
 
+    /**
+     * test that empty html sent by the library is ignored and treated as empty string
+     */
+    public function testEmptyHtml() {
+        $content = [
+            "<p><br></p>" => "",
+            "<p> <br></p>" => "",
+            "<p>foo</p>" => "<p>foo</p>",
+            "<h1></h1><p>paragraph</p> " => "<p>paragraph</p> ",
+            " " => "",
+            " . " => " . ",
+            "\n\n" => ""
+        ];
+        foreach($content as $in => $expected) {
+            $field = TrumboywgEditorField::create("testEmptyHtml", "test", $in);
+            $out = $field->dataValue();
+            $this->assertEquals($expected, $out);
+        }
+    }
+
 }


### PR DESCRIPTION
## Changes

+ add config 'AutoFormat.RemoveEmpty.RemoveNbsp' => true,
+ add config  'AutoFormat.RemoveEmpty' => true
+ if the text value is empty, return an empty value from dataValue
+ use DOMParser in JS to do the same, and set an empty value on the field when the blur event is fired